### PR TITLE
Emit definition occurrence for Kotlin objects

### DIFF
--- a/semanticdb-kotlinc/minimized/src/generatedSnapshots/resources/java/snapshots/ClassConsumer.java
+++ b/semanticdb-kotlinc/minimized/src/generatedSnapshots/resources/java/snapshots/ClassConsumer.java
@@ -1,0 +1,15 @@
+package snapshots;
+
+public class ClassConsumer {
+//           ^^^^^^^^^^^^^ definition snapshots/ClassConsumer# public class ClassConsumer
+//           ^^^^^^^^^^^^^ definition snapshots/ClassConsumer#`<init>`(). public ClassConsumer()
+    public static void run() {
+//                     ^^^ definition snapshots/ClassConsumer#run(). public static void run()
+        System.out.println(new Class().getAsdf());
+//      ^^^^^^ reference java/lang/System#
+//             ^^^ reference java/lang/System#out.
+//                 ^^^^^^^ reference java/io/PrintStream#println(+9).
+//                             ^^^^^ reference snapshots/Class#`<init>`(+1).
+//                                     ^^^^^^^ reference snapshots/Class#getAsdf().
+    }
+}

--- a/semanticdb-kotlinc/minimized/src/generatedSnapshots/resources/java/snapshots/CompanionConsumer.java
+++ b/semanticdb-kotlinc/minimized/src/generatedSnapshots/resources/java/snapshots/CompanionConsumer.java
@@ -8,5 +8,8 @@ public class CompanionConsumer {
 //      ^^^^^^^^^^^^^^ reference snapshots/CompanionOwner#
 //                     ^^^^^^^^^ reference snapshots/CompanionOwner#Companion.
 //                               ^^^^^^ reference snapshots/CompanionOwner#Companion#create().
+        new CompanionOwner().create();
+//          ^^^^^^^^^^^^^^ reference snapshots/CompanionOwner#`<init>`().
+//                           ^^^^^^ reference snapshots/CompanionOwner#create().
     }
 }

--- a/semanticdb-kotlinc/minimized/src/generatedSnapshots/resources/java/snapshots/ObjectKtConsumer.java
+++ b/semanticdb-kotlinc/minimized/src/generatedSnapshots/resources/java/snapshots/ObjectKtConsumer.java
@@ -1,0 +1,13 @@
+package snapshots;
+
+public class ObjectKtConsumer {
+//           ^^^^^^^^^^^^^^^^ definition snapshots/ObjectKtConsumer# public class ObjectKtConsumer
+//           ^^^^^^^^^^^^^^^^ definition snapshots/ObjectKtConsumer#`<init>`(). public ObjectKtConsumer()
+    public static void run() {
+//                     ^^^ definition snapshots/ObjectKtConsumer#run(). public static void run()
+        ObjectKt.INSTANCE.fail("boom");
+//      ^^^^^^^^ reference snapshots/ObjectKt#
+//               ^^^^^^^^ reference snapshots/ObjectKt#INSTANCE.
+//                        ^^^^ reference snapshots/ObjectKt#fail().
+    }
+}

--- a/semanticdb-kotlinc/minimized/src/generatedSnapshots/resources/kotlin/snapshots/Class.kt
+++ b/semanticdb-kotlinc/minimized/src/generatedSnapshots/resources/kotlin/snapshots/Class.kt
@@ -1,7 +1,7 @@
 package snapshots
 //      ^^^^^^^^^ reference snapshots/
 
-class Class constructor(private var banana: Int, apple: String): Throwable(banana.toString()) {
+class Class constructor(private var banana: Int, apple: String): Throwable(banana.toString() + apple) {
 //    ^^^^^ definition snapshots/Class# Class
 //          ^^^^^^^^^^^ definition snapshots/Class#`<init>`(). Class
 //                                  ^^^^^^ definition snapshots/Class#banana. banana
@@ -14,6 +14,8 @@ class Class constructor(private var banana: Int, apple: String): Throwable(banan
 //                                                               ^^^^^^^^^ reference kotlin/Throwable#`<init>`().
 //                                                                         ^^^^^^ reference snapshots/Class#`<init>`().(banana)
 //                                                                                ^^^^^^^^ reference kotlin/Int#toString().
+//                                                                                           ^ reference kotlin/String#plus().
+//                                                                                             ^^^^^ reference snapshots/Class#`<init>`().(apple)
     init {
         println("")
 //      ^^^^^^^ reference kotlin/io/ConsoleKt#println(+1).
@@ -46,5 +48,9 @@ class Class constructor(private var banana: Int, apple: String): Throwable(banan
 //                      ^^^^^^ reference snapshots/Class#banana.
 //                      ^^^^^^ reference snapshots/Class#getBanana().
 //                      ^^^^^^ reference snapshots/Class#setBanana().
+        banana = 42
+//      ^^^^^^ reference snapshots/Class#banana.
+//      ^^^^^^ reference snapshots/Class#getBanana().
+//      ^^^^^^ reference snapshots/Class#setBanana().
     }
 }

--- a/semanticdb-kotlinc/minimized/src/generatedSnapshots/resources/kotlin/snapshots/CompanionOwner.kt
+++ b/semanticdb-kotlinc/minimized/src/generatedSnapshots/resources/kotlin/snapshots/CompanionOwner.kt
@@ -5,9 +5,16 @@ class CompanionOwner {
 //    ^^^^^^^^^^^^^^ definition snapshots/CompanionOwner# CompanionOwner
 //    ^^^^^^^^^^^^^^ definition snapshots/CompanionOwner#`<init>`(). CompanionOwner
     companion object {
+//            ^^^^^^^^^ definition snapshots/CompanionOwner#Companion# Companion
         fun create(): CompanionOwner = CompanionOwner()
 //          ^^^^^^ definition snapshots/CompanionOwner#Companion#create(). create
 //                    ^^^^^^^^^^^^^^ reference snapshots/CompanionOwner#
 //                                     ^^^^^^^^^^^^^^ reference snapshots/CompanionOwner#`<init>`().
     }
+    fun create(): Int = CompanionOwner.create().hashCode()
+//      ^^^^^^ definition snapshots/CompanionOwner#create(). create
+//                ^^^ reference kotlin/Int#
+//                      ^^^^^^^^^^^^^^ reference snapshots/CompanionOwner#Companion#
+//                                     ^^^^^^ reference snapshots/CompanionOwner#Companion#create().
+//                                              ^^^^^^^^ reference snapshots/CompanionOwner#hashCode(+-1).
 }

--- a/semanticdb-kotlinc/minimized/src/generatedSnapshots/resources/kotlin/snapshots/ObjectKt.kt
+++ b/semanticdb-kotlinc/minimized/src/generatedSnapshots/resources/kotlin/snapshots/ObjectKt.kt
@@ -7,12 +7,14 @@ import java.lang.RuntimeException
 //               ^^^^^^^^^^^^^^^^ reference java/lang/RuntimeException#
 
 object ObjectKt {
-→fun fail(message: String?): Nothing {
-//   ^^^^ definition snapshots/ObjectKt#fail(). fail
-//        ^^^^^^^ definition snapshots/ObjectKt#fail().(message) message
-//                 ^^^^^^ reference kotlin/String#
-//                           ^^^^^^^ reference kotlin/Nothing#
-→→throw RuntimeException("")
-//      ^^^^^^^^^^^^^^^^ reference java/lang/RuntimeException#`<init>`(+1).
-→}
+//     ^^^^^^^^ definition snapshots/ObjectKt# ObjectKt
+    fun fail(message: String?): Nothing {
+//      ^^^^ definition snapshots/ObjectKt#fail(). fail
+//           ^^^^^^^ definition snapshots/ObjectKt#fail().(message) message
+//                    ^^^^^^ reference kotlin/String#
+//                              ^^^^^^^ reference kotlin/Nothing#
+        throw RuntimeException(message)
+//            ^^^^^^^^^^^^^^^^ reference java/lang/RuntimeException#`<init>`(+1).
+//                             ^^^^^^^ reference snapshots/ObjectKt#fail().(message)
+    }
 }

--- a/semanticdb-kotlinc/minimized/src/main/java/snapshots/ClassConsumer.java
+++ b/semanticdb-kotlinc/minimized/src/main/java/snapshots/ClassConsumer.java
@@ -1,0 +1,7 @@
+package snapshots;
+
+public class ClassConsumer {
+    public static void run() {
+        System.out.println(new Class().getAsdf());
+    }
+}

--- a/semanticdb-kotlinc/minimized/src/main/java/snapshots/CompanionConsumer.java
+++ b/semanticdb-kotlinc/minimized/src/main/java/snapshots/CompanionConsumer.java
@@ -3,5 +3,6 @@ package snapshots;
 public class CompanionConsumer {
     CompanionConsumer() {
         CompanionOwner.Companion.create();
+        new CompanionOwner().create();
     }
 }

--- a/semanticdb-kotlinc/minimized/src/main/java/snapshots/ObjectKtConsumer.java
+++ b/semanticdb-kotlinc/minimized/src/main/java/snapshots/ObjectKtConsumer.java
@@ -1,0 +1,7 @@
+package snapshots;
+
+public class ObjectKtConsumer {
+    public static void run() {
+        ObjectKt.INSTANCE.fail("boom");
+    }
+}

--- a/semanticdb-kotlinc/minimized/src/main/kotlin/snapshots/Class.kt
+++ b/semanticdb-kotlinc/minimized/src/main/kotlin/snapshots/Class.kt
@@ -1,6 +1,6 @@
 package snapshots
 
-class Class constructor(private var banana: Int, apple: String): Throwable(banana.toString()) {
+class Class constructor(private var banana: Int, apple: String): Throwable(banana.toString() + apple) {
     init {
         println("")
     }
@@ -16,5 +16,6 @@ class Class constructor(private var banana: Int, apple: String): Throwable(banan
     fun run() {
         println(Class::class)
         println("I eat $banana for lunch")
+        banana = 42
     }
 }

--- a/semanticdb-kotlinc/minimized/src/main/kotlin/snapshots/CompanionOwner.kt
+++ b/semanticdb-kotlinc/minimized/src/main/kotlin/snapshots/CompanionOwner.kt
@@ -4,4 +4,5 @@ class CompanionOwner {
     companion object {
         fun create(): CompanionOwner = CompanionOwner()
     }
+    fun create(): Int = CompanionOwner.create().hashCode()
 }

--- a/semanticdb-kotlinc/minimized/src/main/kotlin/snapshots/ObjectKt.kt
+++ b/semanticdb-kotlinc/minimized/src/main/kotlin/snapshots/ObjectKt.kt
@@ -3,7 +3,7 @@ package snapshots
 import java.lang.RuntimeException
 
 object ObjectKt {
-	fun fail(message: String?): Nothing {
-		throw RuntimeException("")
-	}
+    fun fail(message: String?): Nothing {
+        throw RuntimeException(message)
+    }
 }


### PR DESCRIPTION
Previously, semanticdb-kotlinc didn't emit `SymbolOccurrence` for Kotlin objects. This PR fixes that bug and does a few more code cleanups that make it easier to work on the codebase.