### PR TITLE
bump kotlin + compiler api dependency to 1.8.21

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,13 +3,12 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import groovy.lang.Closure
 
 plugins {
-    kotlin("jvm") version "1.5.30"
+    kotlin("jvm") version "1.8.21"
     id("com.github.johnrengelman.shadow") version "7.1.0"
     id("com.palantir.git-version") version "0.12.3"
     id("io.github.gradle-nexus.publish-plugin") version "1.1.0"
     id("com.diffplug.spotless") version "5.17.1"
 }
-
 
 val versionDetails: Closure<VersionDetails> by extra
 

--- a/semanticdb-kotlinc/build.gradle.kts
+++ b/semanticdb-kotlinc/build.gradle.kts
@@ -36,7 +36,7 @@ dependencies {
     testImplementation(kotlin("compiler-embeddable"))
     testImplementation(kotlin("test"))
     testImplementation("io.kotest", "kotest-assertions-core", "4.6.3")
-    testImplementation("com.github.tschuchortdev", "kotlin-compile-testing", "1.4.0")
+    testImplementation("com.github.tschuchortdev", "kotlin-compile-testing", "1.5.0")
     testImplementation("org.junit.jupiter", "junit-jupiter-params", "5.8.1")
     testImplementation("org.jetbrains.kotlin", "kotlin-stdlib-jdk8", "1.5.0") {
         version {

--- a/semanticdb-kotlinc/src/main/kotlin/com/sourcegraph/semanticdb_kotlinc/AnalyzerCommandLineProcessor.kt
+++ b/semanticdb-kotlinc/src/main/kotlin/com/sourcegraph/semanticdb_kotlinc/AnalyzerCommandLineProcessor.kt
@@ -5,6 +5,7 @@ import java.nio.file.Paths
 import org.jetbrains.kotlin.compiler.plugin.AbstractCliOption
 import org.jetbrains.kotlin.compiler.plugin.CliOption
 import org.jetbrains.kotlin.compiler.plugin.CommandLineProcessor
+import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
 import org.jetbrains.kotlin.config.CompilerConfiguration
 import org.jetbrains.kotlin.config.CompilerConfigurationKey
 
@@ -14,6 +15,7 @@ val KEY_SOURCES = CompilerConfigurationKey<Path>(VAL_SOURCES)
 const val VAL_TARGET = "targetroot"
 val KEY_TARGET = CompilerConfigurationKey<Path>(VAL_TARGET)
 
+@OptIn(ExperimentalCompilerApi::class)
 class AnalyzerCommandLineProcessor : CommandLineProcessor {
     override val pluginId: String = "semanticdb-kotlinc"
     override val pluginOptions: Collection<AbstractCliOption> =

--- a/semanticdb-kotlinc/src/main/kotlin/com/sourcegraph/semanticdb_kotlinc/AnalyzerRegistrar.kt
+++ b/semanticdb-kotlinc/src/main/kotlin/com/sourcegraph/semanticdb_kotlinc/AnalyzerRegistrar.kt
@@ -4,9 +4,11 @@ import java.lang.IllegalArgumentException
 import kotlin.contracts.ExperimentalContracts
 import org.jetbrains.kotlin.com.intellij.mock.MockProject
 import org.jetbrains.kotlin.compiler.plugin.ComponentRegistrar
+import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
 import org.jetbrains.kotlin.config.CompilerConfiguration
 import org.jetbrains.kotlin.resolve.jvm.extensions.AnalysisHandlerExtension
 
+@OptIn(ExperimentalCompilerApi::class)
 @ExperimentalContracts
 class AnalyzerRegistrar(private val callback: (Semanticdb.TextDocument) -> Unit = {}) :
     ComponentRegistrar {

--- a/semanticdb-kotlinc/src/test/kotlin/com/sourcegraph/semanticdb_kotlinc/test/AnalyzerTest.kt
+++ b/semanticdb-kotlinc/src/test/kotlin/com/sourcegraph/semanticdb_kotlinc/test/AnalyzerTest.kt
@@ -19,11 +19,12 @@ import kotlin.contracts.ExperimentalContracts
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import org.intellij.lang.annotations.Language
+import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
 import org.junit.jupiter.api.io.TempDir
 
+@OptIn(ExperimentalCompilerApi::class)
 @ExperimentalContracts
 class AnalyzerTest {
-
     fun compileSemanticdb(path: Path, @Language("kotlin") code: String): TextDocument {
         val buildPath = File(path.resolve("build").toString()).apply { mkdir() }
         val source = SourceFile.testKt(code)
@@ -33,7 +34,7 @@ class AnalyzerTest {
             KotlinCompilation()
                 .apply {
                     sources = listOf(source)
-                    compilerPlugins = listOf(AnalyzerRegistrar { document = it })
+                    componentRegistrars = listOf(AnalyzerRegistrar { document = it })
                     verbose = false
                     pluginOptions =
                         listOf(
@@ -128,7 +129,7 @@ class AnalyzerTest {
             KotlinCompilation()
                 .apply {
                     sources = listOf(SourceFile.testKt(""))
-                    compilerPlugins = listOf(AnalyzerRegistrar { throw Exception("sample text") })
+                    componentRegistrars = listOf(AnalyzerRegistrar { throw Exception("sample text") })
                     verbose = false
                     pluginOptions =
                         listOf(
@@ -565,7 +566,7 @@ class AnalyzerTest {
             KotlinCompilation()
                 .apply {
                     sources = listOf(source)
-                    compilerPlugins = listOf(AnalyzerRegistrar())
+                    componentRegistrars = listOf(AnalyzerRegistrar())
                     verbose = false
                     pluginOptions =
                         listOf(

--- a/semanticdb-kotlinc/src/test/kotlin/com/sourcegraph/semanticdb_kotlinc/test/Utils.kt
+++ b/semanticdb-kotlinc/src/test/kotlin/com/sourcegraph/semanticdb_kotlinc/test/Utils.kt
@@ -14,6 +14,7 @@ import org.jetbrains.kotlin.analyzer.AnalysisResult
 import org.jetbrains.kotlin.com.intellij.mock.MockProject
 import org.jetbrains.kotlin.com.intellij.openapi.project.Project
 import org.jetbrains.kotlin.compiler.plugin.ComponentRegistrar
+import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
 import org.jetbrains.kotlin.config.CompilerConfiguration
 import org.jetbrains.kotlin.descriptors.ModuleDescriptor
 import org.jetbrains.kotlin.psi.KtFile
@@ -96,6 +97,7 @@ fun checkContainsExpectedSemanticdb(
     assertSoftly(document.symbolsList) { expectedSymbols?.let { this.shouldContainInOrder(it) } }
 }
 
+@OptIn(ExperimentalCompilerApi::class)
 @ExperimentalContracts
 private fun configureTestCompiler(
     source: SourceFile,
@@ -111,10 +113,11 @@ private fun configureTestCompiler(
         }
 
     val analyzer = semanticdbVisitorAnalyzer(globals, locals, compilation.workingDir.toPath(), hook)
-    compilation.apply { compilerPlugins = listOf(analyzer) }
+    compilation.apply { componentRegistrars = listOf(analyzer) }
     return compilation
 }
 
+@OptIn(ExperimentalCompilerApi::class)
 @ExperimentalContracts
 fun semanticdbVisitorAnalyzer(
     globals: GlobalSymbolsCache,


### PR DESCRIPTION
Buncha deprecation warnings, do we leave versions pre 1.8.21 behind to move to non-deprecated stuff? (see e.g.: https://sourcegraph.com/github.com/JetBrains/kotlin/-/commit/8b42638afa00626078aa7d04ea62a129f0323cdc)

### Test plan

Unit tests :blush: 
