### PR TITLE
fix updating to kotlin 1.8

### DIFF
--- a/semanticdb-kotlinc/minimized/src/generatedSnapshots/resources/semanticdb-kotlinc/minimized/src/main/kotlin/snapshots/Implementations.kt
+++ b/semanticdb-kotlinc/minimized/src/generatedSnapshots/resources/semanticdb-kotlinc/minimized/src/main/kotlin/snapshots/Implementations.kt
@@ -44,7 +44,7 @@ open class Bird : Animal {
 //                               ^^^ reference semanticdb maven . . kotlin/Int#
         get() = 42
 //      ^^^ definition semanticdb maven . . snapshots/Bird#getFavoriteNumber().
-//          documentation ```kt\npublic open fun <get-favoriteNumber>(): kotlin.Int\n```
+//          documentation ```kt\npublic open fun `<get-favoriteNumber>`(): kotlin.Int\n```
 
     override fun sound(): String {
 //               ^^^^^ definition semanticdb maven . . snapshots/Bird#sound().
@@ -68,7 +68,7 @@ class Seagull : Bird() {
 //                               ^^^ reference semanticdb maven . . kotlin/Int#
         get() = 1337
 //      ^^^ definition semanticdb maven . . snapshots/Seagull#getFavoriteNumber().
-//          documentation ```kt\npublic open fun <get-favoriteNumber>(): kotlin.Int\n```
+//          documentation ```kt\npublic open fun `<get-favoriteNumber>`(): kotlin.Int\n```
     override fun sound(): String {
 //               ^^^^^ definition semanticdb maven . . snapshots/Seagull#sound().
 //                     documentation ```kt\npublic open fun sound(): kotlin.String\n```

--- a/semanticdb-kotlinc/src/main/kotlin/com/sourcegraph/semanticdb_kotlinc/SemanticdbTextDocumentBuilder.kt
+++ b/semanticdb-kotlinc/src/main/kotlin/com/sourcegraph/semanticdb_kotlinc/SemanticdbTextDocumentBuilder.kt
@@ -86,7 +86,7 @@ class SemanticdbTextDocumentBuilder(
                         // first is the class itself
                         .drop(1)
                         .filter {
-                            it.fqnString !in isIgnoredSuperClass
+                            it.fqnString(false) !in isIgnoredSuperClass
                         }
                         .flatMap { cache[it] }
                         .map { it.toString() }


### PR DESCRIPTION
`DeclarationDescriptor.fqnString` became a function on upgrading. The use of that was added to main after the previous 1.8 branch was created, and not rebased onto the branch. 

Not entirely sure to me what the `compatibleMode` bool param is about, heres some links I could surface. Appears to be kotlin/native specific
https://youtrack.jetbrains.com/issue/KT-48912
https://sourcegraph.com/github.com/JetBrains/kotlin/-/blob/compiler/ir/serialization.common/src/org/jetbrains/kotlin/backend/common/serialization/mangle/ir/IrMangleComputer.kt?L206-208
https://sourcegraph.com/github.com/JetBrains/kotlin/-/blob/compiler/testData/codegen/box/ir/serializationRegressions/anonFakeOverride.kt?L34-37

### Test plan

Unit tests pass
