### PR TITLE
chore: bump workflow versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,10 +6,11 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-java@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-java@v3
         with: 
           java-version: '8'
           distribution: 'adopt'
+          cache: 'gradle'
       - name: Test
         run: ./gradlew test

--- a/.github/workflows/pr-auditor.yml
+++ b/.github/workflows/pr-auditor.yml
@@ -13,7 +13,6 @@ jobs:
           repository: 'sourcegraph/pr-auditor'
       - uses: actions/setup-go@v4
         with: { go-version: '1.20' }
-
       - run: './check-pr.sh'
         env:
           GITHUB_EVENT_PATH: ${{ env.GITHUB_EVENT_PATH }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,14 +7,15 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Get tag
         id: tag
-        run: echo "::set-output name=version::${GITHUB_REF/refs\/tags\/v/}"
-      - uses: actions/setup-java@v2
+        run: echo "version=${GITHUB_REF/refs\/tags\/v/}" >> $GITHUB_OUTPUT
+      - uses: actions/setup-java@v3
         with: 
           java-version: '8'
           distribution: 'adopt'
+          cache: 'gradle'
       - name: Publish ${{ github.ref }}
         run: ./gradlew -Pversion=${{ steps.tag.outputs.version }} publish
         env:


### PR DESCRIPTION
Updated workflow versions and updated a step to the new format as per https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

### Test plan

N/A workflow files