### PR TITLE
Upgrade to Kotlin 1.9.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,12 +5,24 @@ This codebase implements a Kotlin compiler plugin that can be used together with
 [scip-java](https://sourcegraph.github.io/scip-java) to emit
 [SCIP](https://github.com/sourcegraph/scip) indexes for Kotlin projects.
 
+
 ## Getting started
 
 This project must be used together with scip-java. Visit
 [scip-java](https://sourcegraph.github.io/scip-java/) for instructions on how to
 index Kotlin projects with scip-java. Note that scip-java indexes Kotlin sources
 even if you have no Java code.
+
+## Kotlin version compatibility
+
+Any given release of scip-kotlin only supports one major version of Kotlin.
+Use the table below to find the version of scip-kotlin that matches the Kotlin
+version you are using in your project.
+
+| Kotlin version | scip-kotlin version |
+|----------------|---------------------|
+| 1.8.x          | 0.3.2               |
+| 1.9.x          | 0.4.0               |
 
 ## SemanticDB support
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,7 +4,7 @@ import groovy.lang.Closure
 import org.gradle.jvm.toolchain.internal.CurrentJvmToolchainSpec
 
 plugins {
-    kotlin("jvm") version "1.8.21"
+    kotlin("jvm") version "1.9.22"
     id("com.github.johnrengelman.shadow") version "7.1.0"
     id("com.palantir.git-version") version "0.12.3"
     id("io.github.gradle-nexus.publish-plugin") version "1.1.0"

--- a/semanticdb-kotlinc/build.gradle.kts
+++ b/semanticdb-kotlinc/build.gradle.kts
@@ -35,7 +35,13 @@ dependencies {
     testImplementation(kotlin("compiler-embeddable"))
     testImplementation(kotlin("test"))
     testImplementation("io.kotest", "kotest-assertions-core", "4.6.3")
-    testImplementation("com.github.tschuchortdev", "kotlin-compile-testing", "1.5.0")
+
+    // Unable to use com.github.tschuchortdev:kotlin-compile-testing until 1.9.x support is fixed
+    //   https://github.com/tschuchortdev/kotlin-compile-testing/issues/390
+    // Until then, we use the fork from https://github.com/ZacSweers/kotlin-compile-testing instead.
+    // testImplementation("com.github.tschuchortdev", "kotlin-compile-testing", "1.5.0")
+    testImplementation("dev.zacsweers.kctfork", "core", "0.4.0")
+
     testImplementation("org.junit.jupiter", "junit-jupiter-params", "5.8.1")
     testImplementation("org.jetbrains.kotlin", "kotlin-stdlib-jdk8", "1.5.0") {
         version {

--- a/semanticdb-kotlinc/src/main/kotlin/com/sourcegraph/semanticdb_kotlinc/SemanticdbTextDocumentBuilder.kt
+++ b/semanticdb-kotlinc/src/main/kotlin/com/sourcegraph/semanticdb_kotlinc/SemanticdbTextDocumentBuilder.kt
@@ -15,11 +15,11 @@ import org.jetbrains.kotlin.com.intellij.navigation.NavigationItem
 import org.jetbrains.kotlin.com.intellij.psi.PsiElement
 import org.jetbrains.kotlin.descriptors.*
 import org.jetbrains.kotlin.idea.KotlinLanguage
-import org.jetbrains.kotlin.ir.backend.js.lower.serialization.ir.JsManglerDesc.fqnString
 import org.jetbrains.kotlin.psi.KtConstructor
 import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.psi.KtPropertyAccessor
 import org.jetbrains.kotlin.renderer.DescriptorRenderer
+import org.jetbrains.kotlin.resolve.descriptorUtil.fqNameSafe
 import org.jetbrains.kotlin.resolve.descriptorUtil.getAllSuperClassifiers
 
 @ExperimentalContracts
@@ -86,7 +86,7 @@ class SemanticdbTextDocumentBuilder(
                         // first is the class itself
                         .drop(1)
                         .filter {
-                            it.fqnString(false) !in isIgnoredSuperClass
+                            it.fqNameSafe.toString() !in isIgnoredSuperClass
                         }
                         .flatMap { cache[it] }
                         .map { it.toString() }

--- a/semanticdb-kotlinc/src/test/kotlin/com/sourcegraph/semanticdb_kotlinc/test/SemanticdbSymbolsTest.kt
+++ b/semanticdb-kotlinc/src/test/kotlin/com/sourcegraph/semanticdb_kotlinc/test/SemanticdbSymbolsTest.kt
@@ -7,9 +7,11 @@ import com.sourcegraph.semanticdb_kotlinc.Semanticdb.SymbolOccurrence.Role
 import com.sourcegraph.semanticdb_kotlinc.test.ExpectedSymbols.SemanticdbData
 import com.sourcegraph.semanticdb_kotlinc.test.ExpectedSymbols.SymbolCacheData
 import com.tschuchort.compiletesting.SourceFile
+import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
 import kotlin.contracts.ExperimentalContracts
 import org.junit.jupiter.api.TestFactory
 
+@ExperimentalCompilerApi
 @ExperimentalContracts
 class SemanticdbSymbolsTest {
     @TestFactory

--- a/semanticdb-kotlinc/src/test/kotlin/com/sourcegraph/semanticdb_kotlinc/test/Utils.kt
+++ b/semanticdb-kotlinc/src/test/kotlin/com/sourcegraph/semanticdb_kotlinc/test/Utils.kt
@@ -44,6 +44,7 @@ data class ExpectedSymbols(
 fun SourceFile.Companion.testKt(@Language("kotlin") contents: String): SourceFile =
     kotlin("Test.kt", contents)
 
+@ExperimentalCompilerApi
 @ExperimentalContracts
 fun List<ExpectedSymbols>.mapCheckExpectedSymbols(): List<DynamicTest> =
     this.flatMap { (testName, source, symbolsData, semanticdbData) ->


### PR DESCRIPTION
Fixes #74. My limited understanding of Kotlin compiler compatibility is that this change drops support for 1.8.x. Until we move to the more stable Kotlin compiler API (which I have barely researched), I think it's reasonable to target the latest Kotlin version in scip-kotlin. Users on older versions of Kotlin will need to stay on older versions of scip-kotlin.

### Test plan
Green CI.

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
