### PR TITLE
[scip-kotlin] Use the correct linguist language alias for Kotlin for markdown syntax highlighting

### DIFF
--- a/semanticdb-kotlinc/minimized/src/generatedSnapshots/resources/semanticdb-kotlinc/minimized/src/main/kotlin/snapshots/Class.kt
+++ b/semanticdb-kotlinc/minimized/src/generatedSnapshots/resources/semanticdb-kotlinc/minimized/src/main/kotlin/snapshots/Class.kt
@@ -3,21 +3,21 @@ package snapshots
 
 class Class constructor(private var banana: Int, apple: String) :
 //    ^^^^^ definition semanticdb maven . . snapshots/Class#
-//          documentation ```kt\npublic final class Class : kotlin.Throwable\n```
+//          documentation ```kotlin\npublic final class Class : kotlin.Throwable\n```
 //          relationship is_reference is_implementation semanticdb maven . . kotlin/Throwable#
 //          ^^^^^^^^^^^ definition semanticdb maven . . snapshots/Class#`<init>`().
-//                      documentation ```kt\npublic constructor Class(banana: kotlin.Int, apple: kotlin.String)\n```
+//                      documentation ```kotlin\npublic constructor Class(banana: kotlin.Int, apple: kotlin.String)\n```
 //                                  ^^^^^^ definition semanticdb maven . . snapshots/Class#`<init>`().(banana)
-//                                         documentation ```kt\nvalue-parameter banana: kotlin.Int\n```
+//                                         documentation ```kotlin\nvalue-parameter banana: kotlin.Int\n```
 //                                  ^^^^^^ definition semanticdb maven . . snapshots/Class#banana.
-//                                         documentation ```kt\nprivate final var banana: kotlin.Int\n```
+//                                         documentation ```kotlin\nprivate final var banana: kotlin.Int\n```
 //                                  ^^^^^^ definition semanticdb maven . . snapshots/Class#getBanana().
-//                                         documentation ```kt\nprivate final var banana: kotlin.Int\n```
+//                                         documentation ```kotlin\nprivate final var banana: kotlin.Int\n```
 //                                  ^^^^^^ definition semanticdb maven . . snapshots/Class#setBanana().
-//                                         documentation ```kt\nprivate final var banana: kotlin.Int\n```
+//                                         documentation ```kotlin\nprivate final var banana: kotlin.Int\n```
 //                                          ^^^ reference semanticdb maven . . kotlin/Int#
 //                                               ^^^^^ definition semanticdb maven . . snapshots/Class#`<init>`().(apple)
-//                                                     documentation ```kt\nvalue-parameter apple: kotlin.String\n```
+//                                                     documentation ```kotlin\nvalue-parameter apple: kotlin.String\n```
 //                                                      ^^^^^^ reference semanticdb maven . . kotlin/String#
     Throwable(banana.toString() + apple) {
 //  ^^^^^^^^^ reference semanticdb maven . . kotlin/Throwable#`<init>`().
@@ -32,31 +32,31 @@ class Class constructor(private var banana: Int, apple: String) :
 
   val asdf =
 //    ^^^^ definition semanticdb maven . . snapshots/Class#asdf.
-//         documentation ```kt\npublic final val asdf: kotlin.Any\n```
+//         documentation ```kotlin\npublic final val asdf: kotlin.Any\n```
 //    ^^^^ definition semanticdb maven . . snapshots/Class#getAsdf().
-//         documentation ```kt\npublic final val asdf: kotlin.Any\n```
+//         documentation ```kotlin\npublic final val asdf: kotlin.Any\n```
       object {
         fun doStuff() = Unit
 //          ^^^^^^^ definition local 0
-//                  documentation ```kt\npublic final fun doStuff()\n```
+//                  documentation ```kotlin\npublic final fun doStuff()\n```
 //                      ^^^^ reference semanticdb maven . . kotlin/Unit#
       }
 
   constructor() : this(1, "")
 //^^^^^^^^^^^ definition semanticdb maven . . snapshots/Class#`<init>`(+1).
-//            documentation ```kt\npublic constructor Class()\n```
+//            documentation ```kotlin\npublic constructor Class()\n```
 
   constructor(banana: Int) : this(banana, "")
 //^^^^^^^^^^^ definition semanticdb maven . . snapshots/Class#`<init>`(+2).
-//            documentation ```kt\npublic constructor Class(banana: kotlin.Int)\n```
+//            documentation ```kotlin\npublic constructor Class(banana: kotlin.Int)\n```
 //            ^^^^^^ definition semanticdb maven . . snapshots/Class#`<init>`(+2).(banana)
-//                   documentation ```kt\nvalue-parameter banana: kotlin.Int\n```
+//                   documentation ```kotlin\nvalue-parameter banana: kotlin.Int\n```
 //                    ^^^ reference semanticdb maven . . kotlin/Int#
 //                                ^^^^^^ reference semanticdb maven . . snapshots/Class#`<init>`(+2).(banana)
 
   fun run() {
 //    ^^^ definition semanticdb maven . . snapshots/Class#run().
-//        documentation ```kt\npublic final fun run()\n```
+//        documentation ```kotlin\npublic final fun run()\n```
     println(Class::class)
 //  ^^^^^^^ reference semanticdb maven . . kotlin/io/ConsoleKt#println(+1).
 //          ^^^^^ reference semanticdb maven . . snapshots/Class#

--- a/semanticdb-kotlinc/minimized/src/generatedSnapshots/resources/semanticdb-kotlinc/minimized/src/main/kotlin/snapshots/CompanionOwner.kt
+++ b/semanticdb-kotlinc/minimized/src/generatedSnapshots/resources/semanticdb-kotlinc/minimized/src/main/kotlin/snapshots/CompanionOwner.kt
@@ -3,21 +3,21 @@ package snapshots
 
 class CompanionOwner {
 //    ^^^^^^^^^^^^^^ definition semanticdb maven . . snapshots/CompanionOwner#
-//                   documentation ```kt\npublic final class CompanionOwner\n```
+//                   documentation ```kotlin\npublic final class CompanionOwner\n```
 //    ^^^^^^^^^^^^^^ definition semanticdb maven . . snapshots/CompanionOwner#`<init>`().
-//                   documentation ```kt\npublic constructor CompanionOwner()\n```
+//                   documentation ```kotlin\npublic constructor CompanionOwner()\n```
   companion object {
 //          ^^^^^^^^ definition semanticdb maven . . snapshots/CompanionOwner#Companion# 1:0
-//                   documentation ```kt\npublic companion object\n```
+//                   documentation ```kotlin\npublic companion object\n```
     fun create(): CompanionOwner = CompanionOwner()
 //      ^^^^^^ definition semanticdb maven . . snapshots/CompanionOwner#Companion#create().
-//             documentation ```kt\npublic final fun create(): snapshots.CompanionOwner\n```
+//             documentation ```kotlin\npublic final fun create(): snapshots.CompanionOwner\n```
 //                ^^^^^^^^^^^^^^ reference semanticdb maven . . snapshots/CompanionOwner#
 //                                 ^^^^^^^^^^^^^^ reference semanticdb maven . . snapshots/CompanionOwner#`<init>`().
   }
   fun create(): Int = CompanionOwner.create().hashCode()
 //    ^^^^^^ definition semanticdb maven . . snapshots/CompanionOwner#create().
-//           documentation ```kt\npublic final fun create(): kotlin.Int\n```
+//           documentation ```kotlin\npublic final fun create(): kotlin.Int\n```
 //              ^^^ reference semanticdb maven . . kotlin/Int#
 //                    ^^^^^^^^^^^^^^ reference semanticdb maven . . snapshots/CompanionOwner#Companion#
 //                                   ^^^^^^ reference semanticdb maven . . snapshots/CompanionOwner#Companion#create().

--- a/semanticdb-kotlinc/minimized/src/generatedSnapshots/resources/semanticdb-kotlinc/minimized/src/main/kotlin/snapshots/Docstrings.kt
+++ b/semanticdb-kotlinc/minimized/src/generatedSnapshots/resources/semanticdb-kotlinc/minimized/src/main/kotlin/snapshots/Docstrings.kt
@@ -8,16 +8,16 @@ import java.io.Serializable
 
 abstract class DocstringSuperclass
 //             ^^^^^^^^^^^^^^^^^^^ definition semanticdb maven . . snapshots/DocstringSuperclass#
-//                                 documentation ```kt\npublic abstract class DocstringSuperclass\n```
+//                                 documentation ```kotlin\npublic abstract class DocstringSuperclass\n```
 //             ^^^^^^^^^^^^^^^^^^^ definition semanticdb maven . . snapshots/DocstringSuperclass#`<init>`().
-//                                 documentation ```kt\npublic constructor DocstringSuperclass()\n```
+//                                 documentation ```kotlin\npublic constructor DocstringSuperclass()\n```
 /** Example class docstring. */
 class Docstrings :  DocstringSuperclass(), Serializable {
 //    ^^^^^^^^^^ definition semanticdb maven . . snapshots/Docstrings#
-//               documentation ```kt\npublic final class Docstrings : snapshots.DocstringSuperclass, java.io.Serializable\n```\n\n----\n\n Example class docstring.
+//               documentation ```kotlin\npublic final class Docstrings : snapshots.DocstringSuperclass, java.io.Serializable\n```\n\n----\n\n Example class docstring.
 //               relationship is_reference is_implementation semanticdb maven . . snapshots/DocstringSuperclass#
 //    ^^^^^^^^^^ definition semanticdb maven . . snapshots/Docstrings#`<init>`().
-//               documentation ```kt\npublic constructor Docstrings()\n```\n\n----\n\n Example class docstring.
+//               documentation ```kotlin\npublic constructor Docstrings()\n```\n\n----\n\n Example class docstring.
 //                  ^^^^^^^^^^^^^^^^^^^ reference semanticdb maven . . snapshots/DocstringSuperclass#`<init>`().
 //                                         ^^^^^^^^^^^^ reference semanticdb maven jdk 8 java/io/Serializable#
 }
@@ -25,4 +25,4 @@ class Docstrings :  DocstringSuperclass(), Serializable {
 /** Example method docstring. */
 fun docstrings() { }
 //  ^^^^^^^^^^ definition semanticdb maven . . snapshots/DocstringsKt#docstrings().
-//             documentation ```kt\npublic fun docstrings()\n```\n\n----\n\n Example method docstring.
+//             documentation ```kotlin\npublic fun docstrings()\n```\n\n----\n\n Example method docstring.

--- a/semanticdb-kotlinc/minimized/src/generatedSnapshots/resources/semanticdb-kotlinc/minimized/src/main/kotlin/snapshots/Functions.kt
+++ b/semanticdb-kotlinc/minimized/src/generatedSnapshots/resources/semanticdb-kotlinc/minimized/src/main/kotlin/snapshots/Functions.kt
@@ -3,9 +3,9 @@ package snapshots
 
 fun sampleText(x: String = "") {
 //  ^^^^^^^^^^ definition semanticdb maven . . snapshots/FunctionsKt#sampleText().
-//             documentation ```kt\npublic fun sampleText(x: kotlin.String = ...)\n```
+//             documentation ```kotlin\npublic fun sampleText(x: kotlin.String = ...)\n```
 //             ^ definition semanticdb maven . . snapshots/FunctionsKt#sampleText().(x)
-//               documentation ```kt\nvalue-parameter x: kotlin.String = ...\n```
+//               documentation ```kotlin\nvalue-parameter x: kotlin.String = ...\n```
 //                ^^^^^^ reference semanticdb maven . . kotlin/String#
   println(x)
 //^^^^^^^ reference semanticdb maven . . kotlin/io/ConsoleKt#println(+1).

--- a/semanticdb-kotlinc/minimized/src/generatedSnapshots/resources/semanticdb-kotlinc/minimized/src/main/kotlin/snapshots/Implementations.kt
+++ b/semanticdb-kotlinc/minimized/src/generatedSnapshots/resources/semanticdb-kotlinc/minimized/src/main/kotlin/snapshots/Implementations.kt
@@ -3,14 +3,14 @@ package snapshots
 
 class Overrides : AutoCloseable {
 //    ^^^^^^^^^ definition semanticdb maven . . snapshots/Overrides#
-//              documentation ```kt\npublic final class Overrides : java.lang.AutoCloseable\n```
+//              documentation ```kotlin\npublic final class Overrides : java.lang.AutoCloseable\n```
 //              relationship is_reference is_implementation semanticdb maven jdk 8 java/lang/AutoCloseable#
 //    ^^^^^^^^^ definition semanticdb maven . . snapshots/Overrides#`<init>`().
-//              documentation ```kt\npublic constructor Overrides()\n```
+//              documentation ```kotlin\npublic constructor Overrides()\n```
 //                ^^^^^^^^^^^^^ reference semanticdb maven jdk 8 java/lang/AutoCloseable#
     override fun close() {
 //               ^^^^^ definition semanticdb maven . . snapshots/Overrides#close().
-//                     documentation ```kt\npublic open fun close()\n```
+//                     documentation ```kotlin\npublic open fun close()\n```
 //                     relationship is_reference is_implementation semanticdb maven jdk 8 java/lang/AutoCloseable#close().
         TODO("Not yet implemented")
 //      ^^^^ reference semanticdb maven . . kotlin/StandardKt#TODO(+1).
@@ -19,36 +19,36 @@ class Overrides : AutoCloseable {
 
 interface Animal {
 //        ^^^^^^ definition semanticdb maven . . snapshots/Animal#
-//               documentation ```kt\npublic interface Animal\n```
+//               documentation ```kotlin\npublic interface Animal\n```
     val favoriteNumber: Int
 //      ^^^^^^^^^^^^^^ definition semanticdb maven . . snapshots/Animal#favoriteNumber.
-//                     documentation ```kt\npublic abstract val favoriteNumber: kotlin.Int\n```
+//                     documentation ```kotlin\npublic abstract val favoriteNumber: kotlin.Int\n```
 //      ^^^^^^^^^^^^^^ definition semanticdb maven . . snapshots/Animal#getFavoriteNumber().
-//                     documentation ```kt\npublic abstract val favoriteNumber: kotlin.Int\n```
+//                     documentation ```kotlin\npublic abstract val favoriteNumber: kotlin.Int\n```
 //                      ^^^ reference semanticdb maven . . kotlin/Int#
     fun sound(): String
 //      ^^^^^ definition semanticdb maven . . snapshots/Animal#sound().
-//            documentation ```kt\npublic abstract fun sound(): kotlin.String\n```
+//            documentation ```kotlin\npublic abstract fun sound(): kotlin.String\n```
 //               ^^^^^^ reference semanticdb maven . . kotlin/String#
 }
 open class Bird : Animal {
 //         ^^^^ definition semanticdb maven . . snapshots/Bird#
-//              documentation ```kt\npublic open class Bird : snapshots.Animal\n```
+//              documentation ```kotlin\npublic open class Bird : snapshots.Animal\n```
 //              relationship is_reference is_implementation semanticdb maven . . snapshots/Animal#
 //         ^^^^ definition semanticdb maven . . snapshots/Bird#`<init>`().
-//              documentation ```kt\npublic constructor Bird()\n```
+//              documentation ```kotlin\npublic constructor Bird()\n```
 //                ^^^^^^ reference semanticdb maven . . snapshots/Animal#
     override val favoriteNumber: Int
 //               ^^^^^^^^^^^^^^ definition semanticdb maven . . snapshots/Bird#favoriteNumber.
-//                              documentation ```kt\npublic open val favoriteNumber: kotlin.Int\n```
+//                              documentation ```kotlin\npublic open val favoriteNumber: kotlin.Int\n```
 //                               ^^^ reference semanticdb maven . . kotlin/Int#
         get() = 42
 //      ^^^ definition semanticdb maven . . snapshots/Bird#getFavoriteNumber().
-//          documentation ```kt\npublic open fun `<get-favoriteNumber>`(): kotlin.Int\n```
+//          documentation ```kotlin\npublic open fun `<get-favoriteNumber>`(): kotlin.Int\n```
 
     override fun sound(): String {
 //               ^^^^^ definition semanticdb maven . . snapshots/Bird#sound().
-//                     documentation ```kt\npublic open fun sound(): kotlin.String\n```
+//                     documentation ```kotlin\npublic open fun sound(): kotlin.String\n```
 //                     relationship is_reference is_implementation semanticdb maven . . snapshots/Animal#sound().
 //                        ^^^^^^ reference semanticdb maven . . kotlin/String#
         return "tweet"
@@ -56,22 +56,22 @@ open class Bird : Animal {
 }
 class Seagull : Bird() {
 //    ^^^^^^^ definition semanticdb maven . . snapshots/Seagull#
-//            documentation ```kt\npublic final class Seagull : snapshots.Bird\n```
+//            documentation ```kotlin\npublic final class Seagull : snapshots.Bird\n```
 //            relationship is_reference is_implementation semanticdb maven . . snapshots/Animal#
 //            relationship is_reference is_implementation semanticdb maven . . snapshots/Bird#
 //    ^^^^^^^ definition semanticdb maven . . snapshots/Seagull#`<init>`().
-//            documentation ```kt\npublic constructor Seagull()\n```
+//            documentation ```kotlin\npublic constructor Seagull()\n```
 //              ^^^^ reference semanticdb maven . . snapshots/Bird#`<init>`().
     override val favoriteNumber: Int
 //               ^^^^^^^^^^^^^^ definition semanticdb maven . . snapshots/Seagull#favoriteNumber.
-//                              documentation ```kt\npublic open val favoriteNumber: kotlin.Int\n```
+//                              documentation ```kotlin\npublic open val favoriteNumber: kotlin.Int\n```
 //                               ^^^ reference semanticdb maven . . kotlin/Int#
         get() = 1337
 //      ^^^ definition semanticdb maven . . snapshots/Seagull#getFavoriteNumber().
-//          documentation ```kt\npublic open fun `<get-favoriteNumber>`(): kotlin.Int\n```
+//          documentation ```kotlin\npublic open fun `<get-favoriteNumber>`(): kotlin.Int\n```
     override fun sound(): String {
 //               ^^^^^ definition semanticdb maven . . snapshots/Seagull#sound().
-//                     documentation ```kt\npublic open fun sound(): kotlin.String\n```
+//                     documentation ```kotlin\npublic open fun sound(): kotlin.String\n```
 //                     relationship is_reference is_implementation semanticdb maven . . snapshots/Animal#sound().
 //                     relationship is_reference is_implementation semanticdb maven . . snapshots/Bird#sound().
 //                        ^^^^^^ reference semanticdb maven . . kotlin/String#

--- a/semanticdb-kotlinc/minimized/src/generatedSnapshots/resources/semanticdb-kotlinc/minimized/src/main/kotlin/snapshots/Lambdas.kt
+++ b/semanticdb-kotlinc/minimized/src/generatedSnapshots/resources/semanticdb-kotlinc/minimized/src/main/kotlin/snapshots/Lambdas.kt
@@ -3,33 +3,33 @@ package snapshots
 
 val x = arrayListOf<String>().forEachIndexed { i, s -> println("$i $s") }
 //  ^ definition semanticdb maven . . snapshots/LambdasKt#getX().
-//    documentation ```kt\npublic val x: kotlin.Unit\n```
+//    documentation ```kotlin\npublic val x: kotlin.Unit\n```
 //  ^ definition semanticdb maven . . snapshots/LambdasKt#x.
-//    documentation ```kt\npublic val x: kotlin.Unit\n```
+//    documentation ```kotlin\npublic val x: kotlin.Unit\n```
 //      ^^^^^^^^^^^ reference semanticdb maven . . kotlin/collections/CollectionsKt#arrayListOf().
 //                  ^^^^^^ reference semanticdb maven . . kotlin/String#
 //                            ^^^^^^^^^^^^^^ reference semanticdb maven . . kotlin/collections/CollectionsKt#forEachIndexed(+9).
 //                                             ^ definition local 0
-//                                               documentation ```kt\nvalue-parameter i: kotlin.Int\n```
+//                                               documentation ```kotlin\nvalue-parameter i: kotlin.Int\n```
 //                                                ^ definition local 1
-//                                                  documentation ```kt\nvalue-parameter s: kotlin.String\n```
+//                                                  documentation ```kotlin\nvalue-parameter s: kotlin.String\n```
 //                                                     ^^^^^^^ reference semanticdb maven . . kotlin/io/ConsoleKt#println(+1).
 //                                                               ^ reference local 0
 //                                                                  ^ reference local 1
 
 val y = "fdsa".run { this.toByteArray() }
 //  ^ definition semanticdb maven . . snapshots/LambdasKt#getY().
-//    documentation ```kt\npublic val y: kotlin.ByteArray\n```
+//    documentation ```kotlin\npublic val y: kotlin.ByteArray\n```
 //  ^ definition semanticdb maven . . snapshots/LambdasKt#y.
-//    documentation ```kt\npublic val y: kotlin.ByteArray\n```
+//    documentation ```kotlin\npublic val y: kotlin.ByteArray\n```
 //             ^^^ reference semanticdb maven . . kotlin/StandardKt#run(+1).
 //                        ^^^^^^^^^^^ reference semanticdb maven . . kotlin/text/StringsKt#toByteArray().
 
 val z = y.let { it.size }
 //  ^ definition semanticdb maven . . snapshots/LambdasKt#getZ().
-//    documentation ```kt\npublic val z: kotlin.Int\n```
+//    documentation ```kotlin\npublic val z: kotlin.Int\n```
 //  ^ definition semanticdb maven . . snapshots/LambdasKt#z.
-//    documentation ```kt\npublic val z: kotlin.Int\n```
+//    documentation ```kotlin\npublic val z: kotlin.Int\n```
 //      ^ reference semanticdb maven . . snapshots/LambdasKt#getY().
 //      ^ reference semanticdb maven . . snapshots/LambdasKt#y.
 //        ^^^ reference semanticdb maven . . kotlin/StandardKt#let().

--- a/semanticdb-kotlinc/minimized/src/generatedSnapshots/resources/semanticdb-kotlinc/minimized/src/main/kotlin/snapshots/ObjectKt.kt
+++ b/semanticdb-kotlinc/minimized/src/generatedSnapshots/resources/semanticdb-kotlinc/minimized/src/main/kotlin/snapshots/ObjectKt.kt
@@ -8,12 +8,12 @@ import java.lang.RuntimeException
 
 object ObjectKt {
 //     ^^^^^^^^ definition semanticdb maven . . snapshots/ObjectKt#
-//              documentation ```kt\npublic object ObjectKt\n```
+//              documentation ```kotlin\npublic object ObjectKt\n```
   fun fail(message: String?): Nothing {
 //    ^^^^ definition semanticdb maven . . snapshots/ObjectKt#fail().
-//         documentation ```kt\npublic final fun fail(message: kotlin.String?): kotlin.Nothing\n```
+//         documentation ```kotlin\npublic final fun fail(message: kotlin.String?): kotlin.Nothing\n```
 //         ^^^^^^^ definition semanticdb maven . . snapshots/ObjectKt#fail().(message)
-//                 documentation ```kt\nvalue-parameter message: kotlin.String?\n```
+//                 documentation ```kotlin\nvalue-parameter message: kotlin.String?\n```
 //                  ^^^^^^ reference semanticdb maven . . kotlin/String#
 //                            ^^^^^^^ reference semanticdb maven . . kotlin/Nothing#
     throw RuntimeException(message)

--- a/semanticdb-kotlinc/src/main/kotlin/com/sourcegraph/semanticdb_kotlinc/SemanticdbTextDocumentBuilder.kt
+++ b/semanticdb-kotlinc/src/main/kotlin/com/sourcegraph/semanticdb_kotlinc/SemanticdbTextDocumentBuilder.kt
@@ -163,7 +163,7 @@ class SemanticdbTextDocumentBuilder(
                 is DeclarationDescriptorWithSource -> descriptor.findKDocString() ?: ""
                 else -> ""
             }
-        message = "```kt\n$signature\n```${stripKDocAsterisks(kdoc)}"
+        message = "```kotlin\n$signature\n```${stripKDocAsterisks(kdoc)}"
     }
 
     // Returns the kdoc string with all leading and trailing "/*" tokens removed. Naive

--- a/semanticdb-kotlinc/src/test/kotlin/com/sourcegraph/semanticdb_kotlinc/test/AnalyzerTest.kt
+++ b/semanticdb-kotlinc/src/test/kotlin/com/sourcegraph/semanticdb_kotlinc/test/AnalyzerTest.kt
@@ -106,7 +106,7 @@ class AnalyzerTest {
                     documentation =
                         Documentation {
                             format = Semanticdb.Documentation.Format.MARKDOWN
-                            message = "```kt\npublic final class Banana\n```"
+                            message = "```kotlin\npublic final class Banana\n```"
                         }
                 },
                 SymbolInformation {
@@ -116,7 +116,7 @@ class AnalyzerTest {
                     documentation =
                         Documentation {
                             format = Semanticdb.Documentation.Format.MARKDOWN
-                            message = "```kt\npublic final fun foo()\n```"
+                            message = "```kotlin\npublic final fun foo()\n```"
                         }
                 })
         assertSoftly(document.symbolsList) { withClue(this) { symbols.forEach(::shouldContain) } }

--- a/semanticdb-kotlinc/src/test/kotlin/com/sourcegraph/semanticdb_kotlinc/test/SemanticdbSymbolsTest.kt
+++ b/semanticdb-kotlinc/src/test/kotlin/com/sourcegraph/semanticdb_kotlinc/test/SemanticdbSymbolsTest.kt
@@ -619,7 +619,7 @@ class SemanticdbSymbolsTest {
                                         language = Language.KOTLIN
                                         documentation {
                                             message =
-                                                "```kt\npublic val x: kotlin.String\n```\n\n----\n\n\nhello world\n test content\n"
+                                                "```kotlin\npublic val x: kotlin.String\n```\n\n----\n\n\nhello world\n test content\n"
                                             format = Format.MARKDOWN
                                         }
                                     },
@@ -629,7 +629,7 @@ class SemanticdbSymbolsTest {
                                         language = Language.KOTLIN
                                         documentation {
                                             message =
-                                                "```kt\npublic val x: kotlin.String\n```\n\n----\n\n\nhello world\n test content\n"
+                                                "```kotlin\npublic val x: kotlin.String\n```\n\n----\n\n\nhello world\n test content\n"
                                             format = Format.MARKDOWN
                                         }
                                     }))))


### PR DESCRIPTION
The GitHub-embedded syntax highlighting for markdown uses `linguist` to detect which language to use. For Kotlin there's no alias `kt` so syntax highlighting doesn't work. Use 'kotlin' to correctly pick up the language of the signature blocks.

c.f. https://github.com/github-linguist/linguist/blob/master/lib/linguist/languages.yml#L3660 https://github.com/github-linguist/linguist/blob/master/lib/linguist/languages.yml#L3660

### Test plan

reindex and check correct code is used.

Regenerate snapshot tests (how?)

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
