### PR TITLE
Fix: logic in package name handling is sensitive to trailing semicolon

### DIFF
--- a/semanticdb-kotlinc/src/main/kotlin/com/sourcegraph/semanticdb_kotlinc/AnalyzerCheckers.kt
+++ b/semanticdb-kotlinc/src/main/kotlin/com/sourcegraph/semanticdb_kotlinc/AnalyzerCheckers.kt
@@ -111,6 +111,7 @@ open class AnalyzerCheckers(session: FirSession) : FirAdditionalCheckersExtensio
 
                 var ancestor = fqName
                 var depth = 0
+
                 while (ancestor != FqName.ROOT) {
                     val nameNode = nameList[nameList.lastIndex - depth]
                     val nameSource = nameNode.toKtLightSourceElement(tree)
@@ -126,7 +127,9 @@ open class AnalyzerCheckers(session: FirSession) : FirAdditionalCheckersExtensio
             val fqName = packageDirective.packageFqName
             val source = packageDirective.source
             if (source != null) {
-                val names = source.treeStructure.findLastDescendant(source.lighterASTNode) { true }
+                val names = source.treeStructure.findChildByType(source.lighterASTNode, KtNodeTypes.DOT_QUALIFIED_EXPRESSION) ?:
+                    source.treeStructure.findChildByType(source.lighterASTNode, KtNodeTypes.REFERENCE_EXPRESSION)
+
                 if (names != null) {
                     eachFqNameElement(fqName, source.treeStructure, names) { fqName, name ->
                         visitor?.visitPackage(fqName, name, context)

--- a/semanticdb-kotlinc/src/test/kotlin/com/sourcegraph/semanticdb_kotlinc/test/SemanticdbSymbolsTest.kt
+++ b/semanticdb-kotlinc/src/test/kotlin/com/sourcegraph/semanticdb_kotlinc/test/SemanticdbSymbolsTest.kt
@@ -106,6 +106,7 @@ class SemanticdbSymbolsTest {
                 )
             .mapCheckExpectedSymbols()
 
+
     @TestFactory
     fun `check package symbols`() =
         listOf(


### PR DESCRIPTION
Pointed out by external contributor.

Previous logic would result in a runtime crash if the package declaration clause ended with a semicolon.

The solution is to properly identify what package declaration nodes there can be. I added two distinct tests for this case.

### Test plan

- new tests