### PR TITLE
Minor cleanups in enclosing_range path

### DIFF
--- a/semanticdb-kotlinc/src/main/kotlin/com/sourcegraph/semanticdb_kotlinc/LineMap.kt
+++ b/semanticdb-kotlinc/src/main/kotlin/com/sourcegraph/semanticdb_kotlinc/LineMap.kt
@@ -7,16 +7,9 @@ import org.jetbrains.kotlin.text
 
 /** Maps between an element and its identifier positions */
 class LineMap(private val file: FirFile) {
-    private fun offsetToLineAndCol(offset: Int): Pair<Int, Int>? =
+    /** Returns the 0-based (line, column) pair for a given offset, or null if unavailable. */
+    fun offsetToLineAndCol(offset: Int): Pair<Int, Int>? =
         file.sourceFileLinesMapping?.getLineAndColumnByOffset(offset)
-
-    /** Returns the non-0-based line number for a given offset */
-    fun lineNumberForOffset(offset: Int): Int =
-        file.sourceFileLinesMapping?.getLineByOffset(offset)?.let { it + 1 } ?: 0
-
-    /** Returns the non-0-based column number for a given offset */
-    fun columnForOffset(offset: Int): Int =
-        offsetToLineAndCol(offset)?.second ?: 0
 
     /** Returns the non-0-based start character */
     fun startCharacter(element: KtSourceElement): Int =

--- a/semanticdb-kotlinc/src/main/kotlin/com/sourcegraph/semanticdb_kotlinc/SemanticdbTextDocumentBuilder.kt
+++ b/semanticdb-kotlinc/src/main/kotlin/com/sourcegraph/semanticdb_kotlinc/SemanticdbTextDocumentBuilder.kt
@@ -137,11 +137,12 @@ class SemanticdbTextDocumentBuilder(
     }
 
     private fun semanticdbEnclosingRange(element: KtSourceElement): Semanticdb.Range {
+        val (endLine0, endCol) = lineMap.offsetToLineAndCol(element.endOffset) ?: (0 to 0)
         return Range {
-            startLine = lineMap.lineNumber(element) - 1
             startCharacter = lineMap.startCharacter(element)
-            endLine = lineMap.lineNumberForOffset(element.endOffset) - 1
-            endCharacter = lineMap.columnForOffset(element.endOffset)
+            startLine = lineMap.lineNumber(element) - 1
+            endCharacter = endCol
+            endLine = endLine0
         }
     }
 


### PR DESCRIPTION
Two small cleanups around the `enclosing_range` plumbing added in #123. No behavior change.

**LineMap**: `semanticdbEnclosingRange` looked up the same end offset twice. `lineNumberForOffset` called `getLineByOffset`, and `columnForOffset` called `getLineAndColumnByOffset` (which already includes the line). This PR drops both single-purpose helpers and uses the existing `offsetToLineAndCol` (now public) once at the call site, so a single FIR lookup yields both line and column.

**Field order**: `semanticdbEnclosingRange` assigned the `Range` builder fields in `(startLine, startCharacter, endLine, endCharacter)` order while its sibling `semanticdbRange` uses `(startCharacter, startLine, endCharacter, endLine)`. Align the new function with the existing one for local readability.

Spotted while integrating #123 into a downstream fork. Filing without prior issue since the diff is minimal and self-contained; happy to revise if you'd prefer a different shape.